### PR TITLE
Remove explicit version

### DIFF
--- a/git-town.rb
+++ b/git-town.rb
@@ -4,7 +4,6 @@ class GitTown < Formula
   homepage 'https://github.com/Originate/git-town'
   url 'https://github.com/Originate/git-town/archive/v0.4.1.tar.gz'
   sha1 '4d089310a3368285b16f5ddb2c1bfb0b0b02a29c'
-  version '0.4.1'
 
   def install
     libexec.install Dir['*']


### PR DESCRIPTION
@charlierudolph @allewun 

Homebrew detects the version automatically, hence we can remove the redundant explicit mentioning of it in the formula.