### PR TITLE
Fish autocompletion installation instructions

### DIFF
--- a/git-town.rb
+++ b/git-town.rb
@@ -18,7 +18,7 @@ class GitTown < Formula
     <<-EOS.undent
       To install Fish shell autocompletions, please run
 
-      ln -s #{prefix}/autocomplete/git.fish ~/.config/fish/completions/git.fish
+      ln -s #{libexec}/autocomplete/git.fish ~/.config/fish/completions/git.fish
 
     EOS
   end

--- a/git-town.rb
+++ b/git-town.rb
@@ -35,6 +35,7 @@ class GitTown < Formula
       In a standard setup, this looks like:
       mkdir -p ~/.config/fish/completions
       ln -s #{libexec}/autocomplete/git.fish ~/.config/fish/completions/git.fish
+
     EOS
   end
 end

--- a/git-town.rb
+++ b/git-town.rb
@@ -23,10 +23,18 @@ class GitTown < Formula
 
   def caveats
     <<-EOS.undent
-      To install Fish shell autocompletions, please run
 
+      To install the Fish shell autocompletions,
+      run "git town install-fish-autocompletion"
+      in the terminal.
+
+      To install the completions manually, make
+      #{libexec}/autocomplete/git.fish
+      available as ~/.config/fish/completions/git.fish.
+
+      In a standard setup, this looks like:
+      mkdir -p ~/.config/fish/completions
       ln -s #{libexec}/autocomplete/git.fish ~/.config/fish/completions/git.fish
-
     EOS
   end
 end

--- a/git-town.rb
+++ b/git-town.rb
@@ -12,4 +12,14 @@ class GitTown < Formula
     bin.install_symlink "#{libexec}/helpers"
     man1.install_symlink Dir["#{libexec}/man/man1/*.1"]
   end
+
+
+  def caveats
+    <<-EOS.undent
+      To install Fish shell autocompletions, please run
+
+      ln -s #{prefix}/autocomplete/git.fish ~/.config/fish/completions/git.fish
+
+    EOS
+  end
 end


### PR DESCRIPTION
@charlierudolph @allewun 

This displays instructions on how to install Fish shell autocompletion after the installation.

Depends on https://github.com/Originate/git-town/pull/358

Implements https://github.com/Originate/git-town/issues/284